### PR TITLE
Remove configurability of refreshInterval

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -99,12 +99,6 @@
                         "default": 15
                     }
                 }
-            },
-            "refreshInterval": {
-                "type": "number",
-                "title": "How often to check for new status (seconds)",
-                "required": false,
-                "default": 20
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-hyundai-bluelink",
-    "version": "1.2.13",
+    "version": "1.3.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/config.d.ts
+++ b/src/config.d.ts
@@ -24,5 +24,4 @@ export interface HyundaiConfig extends PlatformConfig {
     credentials: AuthConfig
     vehicles: VehicleConfig[]
     remoteStart: StartConfig
-    refreshInterval: number
 }

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -2,10 +2,12 @@ import { VehicleStatus } from 'bluelinky/dist/interfaces/common.interfaces'
 import { Vehicle } from 'bluelinky/dist/vehicles/vehicle'
 import { EventEmitter } from 'events'
 import { PlatformAccessory } from 'homebridge'
-import { HyundaiConfig } from './config'
 
 import { HyundaiPlatform } from './platform'
 import initServices from './services'
+
+const REFRESH_INTERVAL = 1000 * 60 * 60 // once per hour, per https://github.com/Hacksore/bluelinky/wiki/API-Rate-Limits
+
 export class VehicleAccessory extends EventEmitter {
     private isFetching = false
     constructor(
@@ -16,10 +18,7 @@ export class VehicleAccessory extends EventEmitter {
         super()
         this.setInformation()
         initServices(this)
-        setInterval(
-            this.fetchStatus.bind(this),
-            (<HyundaiConfig>this.platform.config).refreshInterval * 1000
-        )
+        setInterval(this.fetchStatus.bind(this), REFRESH_INTERVAL)
     }
 
     fetchStatus(): void {

--- a/src/services/ignition.ts
+++ b/src/services/ignition.ts
@@ -57,7 +57,10 @@ export class Ignition extends HyundaiService {
     }
     set shouldTurnOn(value: boolean) {
         this._shouldTurnOn = value
-        // Give up after 5 minutes
-        setInterval(() => (this._shouldTurnOn = undefined), 1000 * 5 * 60)
+        // Check on status & reset after 1 minute
+        setTimeout(() => {
+            this.va.fetchStatus()
+            this._shouldTurnOn = undefined
+        }, 1000 * 60)
     }
 }

--- a/src/services/lock.ts
+++ b/src/services/lock.ts
@@ -78,7 +78,10 @@ export class Lock extends HyundaiService {
     }
     set shouldLock(value: boolean) {
         this._shouldLock = value
-        // Give up after 5 minutes
-        setInterval(() => (this._shouldLock = undefined), 1000 * 5 * 60)
+        // Check on status & reset after 1 minute
+        setInterval(() => {
+            this.va.fetchStatus()
+            this._shouldLock = undefined
+        }, 1000 * 60)
     }
 }


### PR DESCRIPTION
It is likely to create a negative experience because of the rate limit. Only check once per hour, and 1 minute after making specific requests.

Signed-off-by: Andrew Thal <467872+athal7@users.noreply.github.com>